### PR TITLE
Configure build process for releases to reuse rich-markdown-editor patches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,15 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2
+
 jobs:
   build:
     docker:
       - image: circleci/node:10.16.3
+
+    branches:
+      ignore:
+        - build
 
     working_directory: ~/repo
 

--- a/.github/workflow/orphan-publish.yml
+++ b/.github/workflow/orphan-publish.yml
@@ -1,0 +1,30 @@
+name: Orphan branch `build` auto publish
+
+on:
+  push:
+    branches:
+      - main  # Set a branch to deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check source out
+        uses: actions/checkout@v2
+
+      - name: Apply NPM-Install Container
+        uses: bahmutov/npm-install@v1
+      
+      - name: Install NPM Packages via Yarn
+        run: yarn install
+
+      - name: Compile Typescript
+        run: yarn build
+
+      - name: Deploy to Orphan Branch `build`
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          external_repository: tud-ise/wegrade
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./
+          publish_branch: build


### PR DESCRIPTION
The release process works like this (`build` is an "orphan" branch):

1. !build: Circle CI runs on all branches other than the `build` branch
2. main: GitHub Actions clones the repository, compiles the JavaScript and then force-pushes its results onto `build`